### PR TITLE
Fix: parse Service options from 'npv.service.options'

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,10 @@ function create (proto) {
           srvc.methods = _.map(srvcChidren, m => mapp(m, METHOD_PROPS))
         }
 
+        if (_.has(npv, 'service.options') && !_.isEmpty(npv.service.options)) {
+          srvc.options = npv.service.options
+        }
+
         namespace.services[k] = srvc
 
         if ((!def.options || _.isEmpty(def.options)) &&

--- a/test/protos/route_guide.proto
+++ b/test/protos/route_guide.proto
@@ -38,6 +38,10 @@ package routeguide;
 
 // Interface exported by the server.
 service RouteGuide {
+  // Custom Options (see: https://developers.google.com/protocol-buffers/docs/proto#customoptions)
+  option (meta).description = "Description";
+  option (option) = "Option";
+
   // A simple RPC.
   //
   // Obtains the feature at a given position.

--- a/test/route_guide_expected.js
+++ b/test/route_guide_expected.js
@@ -131,6 +131,10 @@ const expectedDescriptor = {
       services: {
         RouteGuide: {
           name: 'RouteGuide',
+          options: {
+            '(meta).description': 'Description',
+            '(option)': 'Option'
+          },
           methods: [{
             name: 'GetFeature',
             requestStream: false,


### PR DESCRIPTION
Hi,
with this `proto`:

```
service Echo {
    option (meta).description = "Echo webservice";
    option (meta).basePath = "/echo";

    rpc ....
}
```

Service options was not parsed correctly because options are stored in `npv.service.options`. (i don't know why)

This PR parse `npv.service.options` if defined.

Thanks