### PR TITLE
Add 'root' option for specify the directory in which to search for imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ function create (proto) {
  * friendlier descriptor object with utility methods.
  * If object is passed it's assumed to be an already loaded proto.
  * @param  {String|Object} input path to proto definition or loaded proto object
+ * @param  {String} root specify the directory in which to search for imports
  * @return {Object} the utility descriptor
  * @example
  * const gi = require('grpc-inspect')
@@ -262,9 +263,11 @@ function create (proto) {
  * const d = gi(pbpath)
  * console.dir(d)
  */
-function grpcinspect (input) {
+function grpcinspect (input, root) {
   let proto
-  if (_.isString(input)) {
+  if (_.isString(input) && _.isString(root)) {
+    proto = grpc.load({file: input, root: root})
+  } else if (_.isString(input)) {
     proto = grpc.load(input)
   } else if (_.isObject(input)) {
     proto = input

--- a/test/grpcinspect.test.js
+++ b/test/grpcinspect.test.js
@@ -5,7 +5,9 @@ import grpc from 'grpc'
 const gu = require('../')
 const expected = require('./route_guide_expected')
 
-const PROTO_PATH = path.resolve(__dirname, './protos/route_guide.proto')
+const BASE_PATH = path.resolve(__dirname, './protos')
+const PROTO_PATH = BASE_PATH + '/route_guide.proto'
+const PROTO_PATH_IMPORT = 'subdir/import.proto'
 
 test('should get full descriptor', t => {
   const d = gu(PROTO_PATH)
@@ -15,6 +17,12 @@ test('should get full descriptor', t => {
 
 test('should get full descriptor with loaded proto', t => {
   const d = gu(grpc.load(PROTO_PATH))
+  t.truthy(d)
+  t.deepEqual(d, expected.expectedDescriptor)
+})
+
+test('should get full descriptor with root path specified', t => {
+  const d = gu(PROTO_PATH_IMPORT, BASE_PATH)
   t.truthy(d)
   t.deepEqual(d, expected.expectedDescriptor)
 })

--- a/test/protos/subdir/import.proto
+++ b/test/protos/subdir/import.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+import "route_guide.proto";


### PR DESCRIPTION
Hi,
pass `root` option to `grpc.load`:
* https://github.com/grpc/grpc/blob/master/src/node/index.js#L95

Usefull for `import` other `proto`.

Thanks