### PR TITLE
Importing a file throws "Cannot read property 'fields' of defined"

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,8 +257,8 @@ function doProto13 (k, def, namespace, npv) {
 
       // fill in the message in the name space from the response type
       if (!namespace.messages[method.responseType.name]) {
-        namespace.messages[method.requestType.name] = {
-          name: method.requestType.name
+        namespace.messages[method.responseType.name] = {
+          name: method.responseType.name
         }
       }
       if (!namespace.messages[method.responseType.name].fields) {

--- a/test/grpcinspect.test.js
+++ b/test/grpcinspect.test.js
@@ -9,6 +9,7 @@ const expected = require('./route_guide_expected')
 const BASE_PATH = path.resolve(__dirname, './protos')
 const PROTO_PATH = BASE_PATH + '/route_guide.proto'
 const PROTO_PATH_IMPORT = 'subdir/import.proto'
+const PROTO_PATH_RELATIVE_IMPORT = BASE_PATH + '/relative_import.proto'
 
 const loaded = grpc.load(PROTO_PATH)
 
@@ -93,4 +94,12 @@ test('should get full descriptor with loaded proto version 6', async t => {
   const d = gu(loaded)
   t.truthy(d)
   t.deepEqual(d, expected.expectedDescriptorPB6)
+})
+
+test('should correctly load fields from imports', async t => {
+  const root = await protobuf.load(PROTO_PATH_RELATIVE_IMPORT)
+  const proto = grpc.loadObject(root)
+  const d = gu(proto)
+  t.truthy(d)
+
 })

--- a/test/protos/relative_import.proto
+++ b/test/protos/relative_import.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "subdir/relative_import_messages.proto";
+
+package relative;
+
+service RelativeImport {
+  rpc TestRelativeImport(TestRequest) returns (TestResponse) {}
+}

--- a/test/protos/subdir/relative_import_messages.proto
+++ b/test/protos/subdir/relative_import_messages.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message TestRequest {
+  bool ping = 1;
+}
+
+message TestResponse {
+  bool pong = 1;
+}


### PR DESCRIPTION
Hey, thanks for the great module!

I have a shared common.proto that contains some shared message types - I noticed that if I import it, grpc-inspect would throw an error:

```
TypeError: Cannot read property 'fields' of undefined
at _.forOwn (/usr/src/node_modules/grpc-inspect/index.js:264:56)
```

It looked like this was due to a typo on lines 260-261 and have confirmed with test.

Cheers!