### PR TITLE
Fix incorrect doc/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Sample usage:
 
 ```js
 const gi = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = gi(pbpath)
+const proto = grpc.load(pbpath)
+const d = gi(proto)
 console.dir(d)
 ```
 
@@ -124,9 +126,11 @@ Returns an array of namespace names within the protocol buffer definition
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.log(d.namespaceNames()) // ['routeguide']
 ```
 
@@ -145,9 +149,11 @@ Returns an array of service names
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = const grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = const grpcinspect(proto)
 console.log(d.serviceNames()) // ['RouteGuide']
 ```
 
@@ -167,9 +173,11 @@ Assumes there are no duplicate service names within the definition.
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.dir(d.service('RouteGuide'))
 ```
 
@@ -188,9 +196,11 @@ Returns an array of method names for a service
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.log(d.methodNames('RouteGuide')) // [ 'GetFeature', 'ListFeatures', 'RecordRoute', 'RouteChat' ]
 ```
 
@@ -210,9 +220,11 @@ Assumes there are no duplicate service names within the definition.
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.dir(d.methods('RouteGuide'))
 ```
 
@@ -226,9 +238,11 @@ Returns the internal proto object
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.dir(d.proto())
 ```
 
@@ -247,9 +261,11 @@ Gets the gRPC service / client object / function
 **Example**  
 
 ```js
-const grpcinstect = require('grpc-inspect')
+const grpcinspect = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = grpcinstect(pbpath)
+const proto = grpc.load(pbpath)
+const d = grpcinspect(proto)
 console.dir(d.client('RouteGuide'))
 ```
 
@@ -273,7 +289,7 @@ const gi = require('grpc-inspect')
 const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
 const proto = grpc.load(pbpath)
-const d = gi(pbpath)
+const d = gi(proto)
 console.dir(d)
 ```
 

--- a/index.js
+++ b/index.js
@@ -35,9 +35,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Array} array of names
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.log(d.namespaceNames()) // ['routeguide']
      */
     namespaceNames: function () {
@@ -51,9 +53,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Array} array of names
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = const grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = const grpcinspect(proto)
      * console.log(d.serviceNames()) // ['RouteGuide']
      */
     serviceNames: function (namespace) {
@@ -76,9 +80,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Object} service utility descriptor
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.dir(d.service('RouteGuide'))
      */
     service: function (service) {
@@ -105,9 +111,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Array} array of names
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.log(d.methodNames('RouteGuide')) // [ 'GetFeature', 'ListFeatures', 'RecordRoute', 'RouteChat' ]
      */
     methodNames: function (service) {
@@ -122,9 +130,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Array} array of method utility descriptors
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.dir(d.methods('RouteGuide'))
      */
     methods: function (service) {
@@ -137,9 +147,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Object} the internal proto object
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.dir(d.proto())
      */
     proto: function () {
@@ -152,9 +164,11 @@ function createDescriptor (def, clients, proto) {
      * @return {Object} the Client object
      * @memberof descriptor
      * @example
-     * const grpcinstect = require('grpc-inspect')
+     * const grpcinspect = require('grpc-inspect')
+     * const grpc = require('grpc')
      * const pbpath = path.resolve(__dirname, './route_guide.proto')
-     * const d = grpcinstect(pbpath)
+     * const proto = grpc.load(pbpath)
+     * const d = grpcinspect(proto)
      * console.dir(d.client('RouteGuide'))
      */
     client: function (serviceName) {
@@ -337,7 +351,7 @@ function getFieldDef (f) {
  * const grpc = require('grpc')
  * const pbpath = path.resolve(__dirname, './route_guide.proto')
  * const proto = grpc.load(pbpath)
- * const d = gi(pbpath)
+ * const d = gi(proto)
  * console.dir(d)
  */
 function grpcinspect (input) {
@@ -345,7 +359,7 @@ function grpcinspect (input) {
   if (_.isObject(input)) {
     proto = input
   } else {
-    throw new Error('Invalid input type. Expected a string')
+    throw new Error('Invalid input type. Expected an object')
   }
 
   return create(proto)

--- a/readme.hbs
+++ b/readme.hbs
@@ -39,8 +39,10 @@ Sample usage:
 
 ```js
 const gi = require('grpc-inspect')
+const grpc = require('grpc')
 const pbpath = path.resolve(__dirname, './route_guide.proto')
-const d = gi(pbpath)
+const proto = grpc.load(pbpath)
+const d = gi(proto)
 console.dir(d)
 ```
 


### PR DESCRIPTION
The string argument to `grpcinspect()` was dropped in 757b1a51bd9f5eaebf2a7e1cbfe1fa499879a6e5, but the documentation and examples still showed the old (now invalid) usage.

This PR brings the documentation up to date again with the following fixes:
* Fixed all invalid examples
* Fixed error message in `grpcinspect()`
* Fixed typos _grpcinstect_ to _grpcinspect_
* Regenerated `README.md`